### PR TITLE
Split DataspaceConnectorClient into multiple classes

### DIFF
--- a/src/main/java/de/fraunhofer/isst/configmanager/api/controller/BrokerController.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/controller/BrokerController.java
@@ -3,6 +3,7 @@ package de.fraunhofer.isst.configmanager.api.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.Resource;
 import de.fraunhofer.isst.configmanager.api.BrokerApi;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultBrokerClient;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
 import de.fraunhofer.isst.configmanager.model.config.BrokerStatus;
 import de.fraunhofer.isst.configmanager.api.service.BrokerService;
@@ -34,12 +35,12 @@ import java.net.URI;
 public class BrokerController implements BrokerApi {
 
     transient BrokerService brokerService;
-    transient DefaultConnectorClient client;
+    transient DefaultBrokerClient client;
     transient ObjectMapper objectMapper;
 
     @Autowired
     public BrokerController(final BrokerService brokerService,
-                            final DefaultConnectorClient client,
+                            final DefaultBrokerClient client,
                             final ObjectMapper objectMapper) {
         this.brokerService = brokerService;
         this.client = client;

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceContractController.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceContractController.java
@@ -5,6 +5,7 @@ import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.configmanager.api.ResourceContractApi;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
 import de.fraunhofer.isst.configmanager.api.service.ResourceService;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import de.fraunhofer.isst.configmanager.util.ValidateApiInput;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
@@ -33,12 +34,12 @@ public class ResourceContractController implements ResourceContractApi {
 
     transient ResourceService resourceService;
     transient Serializer serializer;
-    transient DefaultConnectorClient client;
+    transient DefaultResourceClient client;
 
     @Autowired
     public ResourceContractController(final ResourceService resourceService,
                                       final Serializer serializer,
-                                      final DefaultConnectorClient client) {
+                                      final DefaultResourceClient client) {
         this.resourceService = resourceService;
         this.serializer = serializer;
         this.client = client;

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceController.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceController.java
@@ -4,6 +4,7 @@ import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.configmanager.api.ResourceApi;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
 import de.fraunhofer.isst.configmanager.api.service.ResourceService;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import de.fraunhofer.isst.configmanager.util.ValidateApiInput;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
@@ -32,12 +33,12 @@ import java.util.ArrayList;
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 public class ResourceController implements ResourceApi {
     transient ResourceService resourceService;
-    transient DefaultConnectorClient client;
+    transient DefaultResourceClient client;
     transient Serializer serializer;
 
     @Autowired
     public ResourceController(final ResourceService resourceService,
-                              final DefaultConnectorClient client, final Serializer serializer) {
+                              final DefaultResourceClient client, final Serializer serializer) {
         this.resourceService = resourceService;
         this.client = client;
         this.serializer = serializer;

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceRepresentationController.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/controller/ResourceRepresentationController.java
@@ -14,6 +14,7 @@ import de.fraunhofer.isst.configmanager.api.ResourceRepresentationApi;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
 import de.fraunhofer.isst.configmanager.api.service.ConfigModelService;
 import de.fraunhofer.isst.configmanager.api.service.ResourceService;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import de.fraunhofer.isst.configmanager.util.ValidateApiInput;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
@@ -43,13 +44,13 @@ public class ResourceRepresentationController implements ResourceRepresentationA
 
     transient ConfigModelService configModelService;
     transient ResourceService resourceService;
-    transient DefaultConnectorClient client;
+    transient DefaultResourceClient client;
     transient Serializer serializer;
 
     @Autowired
     public ResourceRepresentationController(final ConfigModelService configModelService,
                                             final ResourceService resourceService,
-                                            final DefaultConnectorClient client,
+                                            final DefaultResourceClient client,
                                             final Serializer serializer) {
         this.client = client;
         this.configModelService = configModelService;

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/service/ConnectorRequestService.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/service/ConnectorRequestService.java
@@ -2,6 +2,7 @@ package de.fraunhofer.isst.configmanager.api.service;
 
 import de.fraunhofer.iais.eis.Resource;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -20,11 +21,13 @@ import java.util.List;
 @Transactional
 public class ConnectorRequestService {
 
-    private final transient DefaultConnectorClient client;
+    private final transient DefaultResourceClient resourceClient;
+    private final transient DefaultConnectorClient connectorClient;
 
     @Autowired
-    public ConnectorRequestService(final DefaultConnectorClient client) {
-        this.client = client;
+    public ConnectorRequestService(final DefaultResourceClient resourceClient, final DefaultConnectorClient connectorClient) {
+        this.resourceClient = resourceClient;
+        this.connectorClient = connectorClient;
     }
 
     /**
@@ -35,7 +38,7 @@ public class ConnectorRequestService {
      */
     public List<Resource> requestResourcesFromConnector(final URI recipientId) {
         try {
-            final var connector = client.getBaseConnector(recipientId.toString(), "");
+            final var connector = connectorClient.getBaseConnector(recipientId.toString(), "");
             if (connector != null && connector.getResourceCatalog() != null) {
 
                 final List<Resource> resourceList = new ArrayList<>();
@@ -65,7 +68,7 @@ public class ConnectorRequestService {
     public Resource requestResource(final URI recipientId, final URI requestedResourceId) {
 
         try {
-            final var resource = client.getRequestedResource(recipientId.toString(), requestedResourceId.toString());
+            final var resource = resourceClient.getRequestedResource(recipientId.toString(), requestedResourceId.toString());
             if (resource != null) {
                 return resource;
             } else {
@@ -91,7 +94,7 @@ public class ConnectorRequestService {
                                            final String contractOffer) {
 
         try {
-            return client.requestContractAgreement(recipientId, requestedArtifactId, contractOffer);
+            return connectorClient.requestContractAgreement(recipientId, requestedArtifactId, contractOffer);
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/service/ResourceService.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/service/ResourceService.java
@@ -14,6 +14,7 @@ import de.fraunhofer.iais.eis.RouteStepImpl;
 import de.fraunhofer.iais.eis.util.TypedLiteral;
 import de.fraunhofer.iais.eis.util.Util;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import de.fraunhofer.isst.configmanager.model.configlists.EndpointInformationRepository;
 import de.fraunhofer.isst.configmanager.model.endpointinfo.EndpointInformation;
 import de.fraunhofer.isst.configmanager.util.CalenderUtil;
@@ -42,17 +43,20 @@ public class ResourceService {
     transient ConfigModelService configModelService;
     transient EndpointService endpointService;
     transient EndpointInformationRepository endpointInformationRepository;
-    transient DefaultConnectorClient client;
+    transient DefaultResourceClient resourceClient;
+    transient DefaultConnectorClient connectorClient;
 
     @Autowired
     public ResourceService(final ConfigModelService configModelService,
                            final EndpointService endpointService,
                            final EndpointInformationRepository endpointInformationRepository,
-                           final DefaultConnectorClient client) {
+                           final DefaultResourceClient resourceClient,
+                           final DefaultConnectorClient connectorClient) {
         this.configModelService = configModelService;
         this.endpointService = endpointService;
         this.endpointInformationRepository = endpointInformationRepository;
-        this.client = client;
+        this.resourceClient = resourceClient;
+        this.connectorClient = connectorClient;
     }
 
     /**
@@ -128,7 +132,7 @@ public class ResourceService {
 
         BaseConnector baseConnector = null;
         try {
-            baseConnector = client.getSelfDeclaration();
+            baseConnector = connectorClient.getSelfDeclaration();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
         }
@@ -149,7 +153,7 @@ public class ResourceService {
      */
     public String getOfferedResourcesAsJsonString() {
         try {
-            return client.getOfferedResourcesAsJsonString();
+            return resourceClient.getOfferedResourcesAsJsonString();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             return null;
@@ -163,7 +167,7 @@ public class ResourceService {
      */
     public String getRequestedResourcesAsJsonString() {
         try {
-            return client.getRequestedResourcesAsJsonString();
+            return resourceClient.getRequestedResourcesAsJsonString();
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             return null;

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultBrokerClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultBrokerClient.java
@@ -1,0 +1,49 @@
+package de.fraunhofer.isst.configmanager.connector.clients;
+
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.URI;
+
+public interface DefaultBrokerClient {
+
+    /**
+     * The method helps to update connector in the broker. For this only the id of the
+     * corresponding broker is necessary.
+     *
+     * @param brokerURI URI of the broker to update/register
+     * @return Response of the update/register request of the connector
+     * @throws IOException when sending the request fails
+     */
+    Response updateAtBroker(String brokerURI) throws IOException;
+
+    /**
+     * The method removes the connector from the corresponding broker. For this only the id of
+     * the broker is necessary.
+     *
+     * @param brokerURI URI of the broker to unregister
+     * @return Response of the unregister request of the connector
+     * @throws IOException when sending the request fails
+     */
+    String unregisterAtBroker(String brokerURI) throws IOException;
+
+    /**
+     * Send a Resource update request to a target broker.
+     *
+     * @param brokerUri  URI of the Broker
+     * @param resourceID ID of the Resource that will be created
+     * @return Response of the target Connector
+     * @throws IOException when serializing of the Resource, or sending of the request fails
+     */
+    String updateResourceAtBroker(String brokerUri, URI resourceID) throws IOException;
+
+    /**
+     * Send a resource deletion request to a target broker.
+     *
+     * @param brokerUri  URI of the Broker
+     * @param resourceID ID of the Resource to delete
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String deleteResourceAtBroker(String brokerUri, URI resourceID) throws IOException;
+}

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultConnectorClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultConnectorClient.java
@@ -2,13 +2,8 @@ package de.fraunhofer.isst.configmanager.connector.clients;
 
 import de.fraunhofer.iais.eis.BaseConnector;
 import de.fraunhofer.iais.eis.ConfigurationModel;
-import de.fraunhofer.iais.eis.Representation;
-import de.fraunhofer.iais.eis.Resource;
-import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceRepresentation;
-import okhttp3.Response;
 
 import java.io.IOException;
-import java.net.URI;
 
 /**
  * The interface DefaultConnectorClient defines methods that are implemented to make
@@ -24,26 +19,6 @@ public interface DefaultConnectorClient {
      * @throws IOException if connection fails
      */
     void getConnectorStatus() throws IOException;
-
-    /**
-     * The method helps to update connector in the broker. For this only the id of the
-     * corresponding broker is necessary.
-     *
-     * @param brokerURI URI of the broker to update/register
-     * @return Response of the update/register request of the connector
-     * @throws IOException when sending the request fails
-     */
-    Response updateAtBroker(String brokerURI) throws IOException;
-
-    /**
-     * The method removes the connector from the corresponding broker. For this only the id of
-     * the broker is necessary.
-     *
-     * @param brokerURI URI of the broker to unregister
-     * @return Response of the unregister request of the connector
-     * @throws IOException when sending the request fails
-     */
-    String unregisterAtBroker(String brokerURI) throws IOException;
 
     /**
      * The method returns the current configuration model.
@@ -74,121 +49,6 @@ public interface DefaultConnectorClient {
     BaseConnector getBaseConnector(String accessURL, String resourceId) throws IOException;
 
     /**
-     * This method returns the uuid of a resource and the resource.
-     *
-     * @param accessURL  url of the connector
-     * @param resourceId id of the resource
-     * @return map from the id of the resource and the resource itself
-     */
-    Resource getRequestedResource(String accessURL, String resourceId) throws IOException;
-
-
-    /**
-     * Send a Resource update Request to a target Connector.
-     *
-     * @param resourceID ID of the Resource that will be created
-     * @param resource   Resource to create
-     * @return Response of the target Connector
-     * @throws IOException when serializing of the Resource, or sending of the request fails
-     */
-    String updateResource(URI resourceID, Resource resource) throws IOException;
-
-    /**
-     * Send a resource creation request to a target connector.
-     *
-     * @param resource Resource that will be created
-     * @return Response of the target Connector
-     * @throws IOException when serializing of the Resource, or sending of the request fails
-     */
-    String registerResource(Resource resource) throws IOException;
-
-    /**
-     * Send a resource deletion request to a target connector.
-     *
-     * @param resourceID ID of the Resource to delete
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String deleteResource(URI resourceID) throws IOException;
-
-    /**
-     * Send a Resource update request to a target broker.
-     *
-     * @param brokerUri  URI of the Broker
-     * @param resourceID ID of the Resource that will be created
-     * @return Response of the target Connector
-     * @throws IOException when serializing of the Resource, or sending of the request fails
-     */
-    String updateResourceAtBroker(String brokerUri, URI resourceID) throws IOException;
-
-    /**
-     * Send a resource deletion request to a target broker.
-     *
-     * @param brokerUri  URI of the Broker
-     * @param resourceID ID of the Resource to delete
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String deleteResourceAtBroker(String brokerUri, URI resourceID) throws IOException;
-
-    /**
-     * Send a resource representation deletion request to a connector.
-     *
-     * @param resourceID       ID of the Resource for which the representation is deleted
-     * @param representationID ID of the Representation to delete
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String deleteResourceRepresentation(String resourceID, String representationID) throws IOException;
-
-    /**
-     * Send a resource representation creation request to the connector.
-     *
-     * @param resourceID     ID of the Resource for which the representation is registered
-     * @param representation representation to be registered
-     * @param endpointId ID of endpoint of the resource
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String registerResourceRepresentation(String resourceID, Representation representation,
-                                          String endpointId) throws IOException;
-
-    /**
-     * Send a resource representation update request to a connector.
-     *
-     * @param resourceID       ID of the Resource for which the representation is updated
-     * @param representationID ID of the representation to be updated
-     * @param representation   representation to be updated
-     * @param endpointId        ID of endpoint of the resource
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String updateResourceRepresentation(String resourceID, String representationID,
-                                        Representation representation, String endpointId) throws IOException;
-
-    /**
-     * Updates a custom {@link ResourceRepresentation} at a connector.
-     *
-     * @param resourceID             ID of the Resource for which the representation is updated
-     * @param representationID       ID of the representation to be updated
-     * @param resourceRepresentation representation to be updated
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String updateCustomResourceRepresentation(String resourceID, String representationID,
-                                              ResourceRepresentation resourceRepresentation) throws IOException;
-
-    /**
-     * Updates a resource contract at a connector.
-     *
-     * @param resourceID ID of the Resource for which the contract is updated
-     * @param contract   contract to be created
-     * @return Response of the target Connector
-     * @throws IOException when an error occurs while sending the request
-     */
-    String updateResourceContract(String resourceID, String contract) throws IOException;
-
-    /**
      * Returns the policy pattern for a given string.
      *
      * @param policy string, representing a policy
@@ -205,22 +65,6 @@ public interface DefaultConnectorClient {
      * @throws IOException when an error occurs while sending the request
      */
     BaseConnector getSelfDeclaration() throws IOException;
-
-    /**
-     * Returns the offered resources of the self declaration of a connector.
-     *
-     * @return json-string with all offered resources
-     * @throws IOException when an error occurs while sending the request
-     */
-    String getOfferedResourcesAsJsonString() throws IOException;
-
-    /**
-     * Returns the requested resources of the self declaration of a connector.
-     *
-     * @return json-string with all requested resources
-     * @throws IOException when an error occurs while sending the request
-     */
-    String getRequestedResourcesAsJsonString() throws IOException;
 
     /**
      * Sends a contract request to a connector by building an ContractRequestMessage.

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultResourceClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/clients/DefaultResourceClient.java
@@ -1,0 +1,123 @@
+package de.fraunhofer.isst.configmanager.connector.clients;
+
+import de.fraunhofer.iais.eis.Representation;
+import de.fraunhofer.iais.eis.Resource;
+import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceRepresentation;
+
+import java.io.IOException;
+import java.net.URI;
+
+public interface DefaultResourceClient {
+
+    /**
+     * This method returns the uuid of a resource and the resource.
+     *
+     * @param accessURL  url of the connector
+     * @param resourceId id of the resource
+     * @return map from the id of the resource and the resource itself
+     */
+    Resource getRequestedResource(String accessURL, String resourceId) throws IOException;
+
+
+    /**
+     * Send a Resource update Request to a target Connector.
+     *
+     * @param resourceID ID of the Resource that will be created
+     * @param resource   Resource to create
+     * @return Response of the target Connector
+     * @throws IOException when serializing of the Resource, or sending of the request fails
+     */
+    String updateResource(URI resourceID, Resource resource) throws IOException;
+
+    /**
+     * Send a resource creation request to a target connector.
+     *
+     * @param resource Resource that will be created
+     * @return Response of the target Connector
+     * @throws IOException when serializing of the Resource, or sending of the request fails
+     */
+    String registerResource(Resource resource) throws IOException;
+
+    /**
+     * Send a resource deletion request to a target connector.
+     *
+     * @param resourceID ID of the Resource to delete
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String deleteResource(URI resourceID) throws IOException;
+
+    /**
+     * Send a resource representation deletion request to a connector.
+     *
+     * @param resourceID       ID of the Resource for which the representation is deleted
+     * @param representationID ID of the Representation to delete
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String deleteResourceRepresentation(String resourceID, String representationID) throws IOException;
+
+    /**
+     * Send a resource representation creation request to the connector.
+     *
+     * @param resourceID     ID of the Resource for which the representation is registered
+     * @param representation representation to be registered
+     * @param endpointId ID of endpoint of the resource
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String registerResourceRepresentation(String resourceID, Representation representation,
+                                          String endpointId) throws IOException;
+
+    /**
+     * Send a resource representation update request to a connector.
+     *
+     * @param resourceID       ID of the Resource for which the representation is updated
+     * @param representationID ID of the representation to be updated
+     * @param representation   representation to be updated
+     * @param endpointId        ID of endpoint of the resource
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String updateResourceRepresentation(String resourceID, String representationID,
+                                        Representation representation, String endpointId) throws IOException;
+
+    /**
+     * Updates a custom {@link ResourceRepresentation} at a connector.
+     *
+     * @param resourceID             ID of the Resource for which the representation is updated
+     * @param representationID       ID of the representation to be updated
+     * @param resourceRepresentation representation to be updated
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String updateCustomResourceRepresentation(String resourceID, String representationID,
+                                              ResourceRepresentation resourceRepresentation) throws IOException;
+
+    /**
+     * Updates a resource contract at a connector.
+     *
+     * @param resourceID ID of the Resource for which the contract is updated
+     * @param contract   contract to be created
+     * @return Response of the target Connector
+     * @throws IOException when an error occurs while sending the request
+     */
+    String updateResourceContract(String resourceID, String contract) throws IOException;
+
+    /**
+     * Returns the offered resources of the self declaration of a connector.
+     *
+     * @return json-string with all offered resources
+     * @throws IOException when an error occurs while sending the request
+     */
+    String getOfferedResourcesAsJsonString() throws IOException;
+
+    /**
+     * Returns the requested resources of the self declaration of a connector.
+     *
+     * @return json-string with all requested resources
+     * @throws IOException when an error occurs while sending the request
+     */
+    String getRequestedResourcesAsJsonString() throws IOException;
+
+}

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceBrokerClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceBrokerClient.java
@@ -1,0 +1,134 @@
+package de.fraunhofer.isst.configmanager.connector.dataspaceconnector;
+
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultBrokerClient;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@ConditionalOnExpression("${dataspace.connector.enabled:false}")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DataspaceBrokerClient extends DataspaceClient implements DefaultBrokerClient {
+
+    public DataspaceBrokerClient(ResourceMapper dataSpaceConnectorResourceMapper) {
+        super(dataSpaceConnectorResourceMapper);
+    }
+
+    @Override
+    public Response updateAtBroker(final String brokerURI) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient updateAtBroker] updating connector %s at broker %s",
+                dataSpaceConnectorHost,
+                brokerURI));
+
+        final var builder = getRequestBuilder();
+        builder.url(new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/broker/update")
+                .addQueryParameter("broker", brokerURI)
+                .build());
+        builder.post(RequestBody.create(brokerURI, okhttp3.MediaType.parse("text/html")));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+
+        return DispatchRequest.sendToDataspaceConnector(request);
+    }
+
+    @Override
+    public String unregisterAtBroker(final String brokerURI) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient unregisterAtBroker] unregistering connector %s at broker %s",
+                dataSpaceConnectorHost,
+                brokerURI));
+
+        final var builder = getRequestBuilder();
+        builder.url(new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/broker/unregister")
+                .addQueryParameter("broker", brokerURI)
+                .build());
+        builder.post(RequestBody.create(brokerURI, okhttp3.MediaType.parse("text/html")));
+        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
+                dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+
+        return Objects.requireNonNull(DispatchRequest.sendToDataspaceConnector(request).body()).string();
+    }
+
+    @Override
+    public String updateResourceAtBroker(final String brokerUri, final URI resourceID) throws IOException {
+        log.info(String.format("---- [DataspaceConnectorClient updateResourceAtBroker] updating resource at Broker %s", brokerUri));
+
+        final var path = resourceID.getPath();
+        final var idStr = path.substring(path.lastIndexOf('/') + 1);
+        final var resourceUUID = UUID.fromString(idStr);
+
+        final var builder = getRequestBuilder();
+        builder.url(new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/broker/update/" + resourceUUID)
+                .addQueryParameter("broker", brokerUri)
+                .build());
+        builder.post(RequestBody.create(new byte[0], null));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient updateResourceAtBroker] Updating Resource at Broker failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String deleteResourceAtBroker(final String brokerUri, final URI resourceID) throws IOException {
+        log.info(String.format("---- [DataspaceConnectorClient deleteResourceAtBroker] Deleting resource %s at Broker %s", resourceID, brokerUri));
+
+        final var path = resourceID.getPath();
+        final var idStr = path.substring(path.lastIndexOf('/') + 1);
+        final var builder = getRequestBuilder();
+        builder.url(new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/broker/remove/" + idStr)
+                .addQueryParameter("broker", brokerUri)
+                .build());
+        builder.post(RequestBody.create(new byte[0], null));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient deleteResourceAtBroker] Deleting Resource at Broker failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+}

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceClient.java
@@ -1,0 +1,53 @@
+package de.fraunhofer.isst.configmanager.connector.dataspaceconnector;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@FieldDefaults(level = AccessLevel.PROTECTED)
+public abstract class DataspaceClient {
+    final static Serializer SERIALIZER = new Serializer();
+    final static ObjectMapper MAPPER = new ObjectMapper();
+
+    @Value("${dataspace.connector.host}")
+    transient String dataSpaceConnectorHost;
+
+    @Value("${dataspace.connector.api.username}")
+    transient String dataSpaceConnectorApiUsername;
+
+    @Value("${dataspace.connector.api.password}")
+    transient String dataSpaceConnectorApiPassword;
+
+    @Value("${dataspace.connector.port}")
+    transient Integer dataSpaceConnectorPort;
+
+    transient String protocol;
+
+    final transient ResourceMapper dataSpaceConnectorResourceMapper;
+
+    String connectorBaseUrl = "";
+
+    public DataspaceClient(final ResourceMapper dataSpaceConnectorResourceMapper) {
+        this.dataSpaceConnectorResourceMapper = dataSpaceConnectorResourceMapper;
+    }
+
+    @Autowired
+    public void setProtocol(final @Value("${dataspace.communication.ssl}") String https) {
+        protocol = Boolean.parseBoolean(https) ? "https" : "http";
+        connectorBaseUrl = protocol + "://" + dataSpaceConnectorHost + ":" + dataSpaceConnectorPort + "/";
+
+        log.info("---- [DataspaceConnectorClient setProtocol] Communication Protocol with DataspaceConnector is: " + protocol);
+    }
+
+    @NotNull
+    protected Request.Builder getRequestBuilder() {
+        return new Request.Builder();
+    }
+}

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceConnectorClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceConnectorClient.java
@@ -1,33 +1,19 @@
 package de.fraunhofer.isst.configmanager.connector.dataspaceconnector;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import de.fraunhofer.iais.eis.BaseConnector;
 import de.fraunhofer.iais.eis.ConfigurationModel;
-import de.fraunhofer.iais.eis.Representation;
-import de.fraunhofer.iais.eis.Resource;
-import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
-import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.BackendSource;
-import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceRepresentation;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Credentials;
 import okhttp3.HttpUrl;
-import okhttp3.Request;
 import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.jetbrains.annotations.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * An implementation of the interface DefaultConnectorClient for the DataspaceConnector.
@@ -36,38 +22,10 @@ import java.util.UUID;
 @Service
 @ConditionalOnExpression("${dataspace.connector.enabled:false}")
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class DataspaceConnectorClient implements DefaultConnectorClient {
-    final static Serializer SERIALIZER = new Serializer();
-    final static ObjectMapper MAPPER = new ObjectMapper();
+public class DataspaceConnectorClient extends DataspaceClient implements DefaultConnectorClient {
 
-    @Value("${dataspace.connector.host}")
-    transient String dataSpaceConnectorHost;
-
-    @Value("${dataspace.connector.api.username}")
-    transient String dataSpaceConnectorApiUsername;
-
-    @Value("${dataspace.connector.api.password}")
-    transient String dataSpaceConnectorApiPassword;
-
-    @Value("${dataspace.connector.port}")
-    transient Integer dataSpaceConnectorPort;
-
-    transient String protocol;
-
-    final transient ResourceMapper dataSpaceConnectorResourceMapper;
-
-    String connectorBaseUrl = "";
-
-    public DataspaceConnectorClient(final ResourceMapper dataSpaceConnectorResourceMapper) {
-        this.dataSpaceConnectorResourceMapper = dataSpaceConnectorResourceMapper;
-    }
-
-    @Autowired
-    public void setProtocol(final @Value("${dataspace.communication.ssl}") String https) {
-        protocol = Boolean.parseBoolean(https) ? "https" : "http";
-        connectorBaseUrl = protocol + "://" + dataSpaceConnectorHost + ":" + dataSpaceConnectorPort + "/";
-
-        log.info("---- [DataspaceConnectorClient setProtocol] Communication Protocol with DataspaceConnector is: " + protocol);
+    public DataspaceConnectorClient(ResourceMapper dataSpaceConnectorResourceMapper) {
+        super(dataSpaceConnectorResourceMapper);
     }
 
     @Override
@@ -77,54 +35,6 @@ public class DataspaceConnectorClient implements DefaultConnectorClient {
         builder.get();
         final var request = builder.build();
         DispatchRequest.sendToDataspaceConnector(request);
-    }
-
-    @Override
-    public Response updateAtBroker(final String brokerURI) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient updateAtBroker] updating connector %s at broker %s",
-                dataSpaceConnectorHost,
-                brokerURI));
-
-        final var builder = getRequestBuilder();
-        builder.url(new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/broker/update")
-                .addQueryParameter("broker", brokerURI)
-                .build());
-        builder.post(RequestBody.create(brokerURI, okhttp3.MediaType.parse("text/html")));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-
-        return DispatchRequest.sendToDataspaceConnector(request);
-    }
-
-    @Override
-    public String unregisterAtBroker(final String brokerURI) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient unregisterAtBroker] unregistering connector %s at broker %s",
-                dataSpaceConnectorHost,
-                brokerURI));
-
-        final var builder = getRequestBuilder();
-        builder.url(new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/broker/unregister")
-                .addQueryParameter("broker", brokerURI)
-                .build());
-        builder.post(RequestBody.create(brokerURI, okhttp3.MediaType.parse("text/html")));
-        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
-                dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-
-        return Objects.requireNonNull(DispatchRequest.sendToDataspaceConnector(request).body()).string();
     }
 
     @Override
@@ -192,43 +102,6 @@ public class DataspaceConnectorClient implements DefaultConnectorClient {
     }
 
     @Override
-    public String getOfferedResourcesAsJsonString() throws IOException {
-        final var baseConnectorNode = getJsonNodeOfBaseConnector();
-        final var offeredResourceNode = baseConnectorNode.findValue("ids:offeredResource");
-        return offeredResourceNode.toString();
-    }
-
-    @Override
-    public String getRequestedResourcesAsJsonString() throws IOException {
-        final var baseConnectorNode = getJsonNodeOfBaseConnector();
-        final var requestedResourceNode = baseConnectorNode.findValue("ids:requestedResource");
-        return requestedResourceNode.toString();
-    }
-
-    private JsonNode getJsonNodeOfBaseConnector() throws IOException {
-        final var connectorUrl = connectorBaseUrl + "admin/api/connector";
-
-        final var builder = getRequestBuilder();
-        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
-                dataSpaceConnectorApiPassword));
-        builder.url(connectorUrl);
-        builder.get();
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient getJsonNodeOfBaseConnector] Could not get BaseConnector");
-        }
-
-        final var body = Objects.requireNonNull(response.body()).string();
-        final var mapper = new ObjectMapper();
-
-        return mapper.readTree(body);
-    }
-
-
-    @Override
     public boolean sendConfiguration(final String configurationModel) throws IOException {
         log.info(String.format("---- [DataspaceConnectorClient sendConfiguration] sending new configuration to %s", dataSpaceConnectorHost));
 
@@ -293,44 +166,6 @@ public class DataspaceConnectorClient implements DefaultConnectorClient {
     }
 
     @Override
-    public Resource getRequestedResource(final String accessURL, final String resourceId) throws IOException {
-        final var builder = getRequestBuilder();
-        final var urlBuilder = new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/request/description")
-                .addQueryParameter("recipient", accessURL)
-                .addQueryParameter("requestedResource", resourceId);
-
-        final var url = urlBuilder.build();
-        builder.url(url);
-        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-        builder.post(RequestBody.create(new byte[0], null));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn(String.format("---- [DataspaceConnectorClient getRequestedResource] Could not get BaseConnector from %s!", dataSpaceConnectorHost));
-        }
-
-        final var body = Objects.requireNonNull(response.body()).string();
-        final var splitBody = body.split("\n", 2);
-        final var resource = splitBody[1].substring(10);
-
-        Resource deserializedResource = null;
-        try {
-            deserializedResource = SERIALIZER.deserialize(resource, Resource.class);
-        } catch (IOException e) {
-            log.error("---- [DataspaceConnectorClient getRequestedResource] SERIALIZER.deserialize threw IOException");
-            log.error(e.getMessage(), e);
-        }
-
-        return deserializedResource;
-    }
-
-    @Override
     public String requestContractAgreement(final String recipientId,
                                            final String requestedArtifactId,
                                            final String contractOffer) throws IOException {
@@ -366,296 +201,6 @@ public class DataspaceConnectorClient implements DefaultConnectorClient {
     }
 
     @Override
-    public String registerResource(final Resource resource) throws IOException {
-        log.info("---- [DataspaceConnectorClient registerResource] Registering resource...");
-
-        final var mappedResource = dataSpaceConnectorResourceMapper.getMetadata(resource);
-        final var resourceJsonLD = MAPPER.writeValueAsString(mappedResource);
-
-        log.info("---- [DataspaceConnectorClient registerResource] New resource: " + resourceJsonLD);
-
-        final var builder = getRequestBuilder();
-        final var path = resource.getId().getPath();
-        final var idStr = path.substring(path.lastIndexOf('/') + 1);
-
-        final var url = new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/resources/resource")
-                .addQueryParameter("id", idStr)
-                .build();
-        builder.url(url);
-        builder.post(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld" +
-                "+json")));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        log.info("---- [DataspaceConnectorClient registerResource] " + url.toString());
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient registerResource] Registering Resource failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String deleteResource(final URI resourceID) throws IOException {
-        log.info(String.format("---- [DataspaceConnectorClient deleteResource] deleting resource %s at %s", resourceID,
-                dataSpaceConnectorHost));
-
-        final var path = resourceID.getPath();
-        final var idStr = path.substring(path.lastIndexOf('/') + 1);
-
-        final var builder = getRequestBuilder();
-        builder.url(connectorBaseUrl + "admin/api/resources/" + idStr);
-        builder.delete();
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient deleteResource] Deleting Resource failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String updateResourceAtBroker(final String brokerUri, final URI resourceID) throws IOException {
-        log.info(String.format("---- [DataspaceConnectorClient updateResourceAtBroker] updating resource at Broker %s", brokerUri));
-
-        final var path = resourceID.getPath();
-        final var idStr = path.substring(path.lastIndexOf('/') + 1);
-        final var resourceUUID = UUID.fromString(idStr);
-
-        final var builder = getRequestBuilder();
-        builder.url(new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/broker/update/" + resourceUUID)
-                .addQueryParameter("broker", brokerUri)
-                .build());
-        builder.post(RequestBody.create(new byte[0], null));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient updateResourceAtBroker] Updating Resource at Broker failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String deleteResourceAtBroker(final String brokerUri, final URI resourceID) throws IOException {
-        log.info(String.format("---- [DataspaceConnectorClient deleteResourceAtBroker] Deleting resource %s at Broker %s", resourceID, brokerUri));
-
-        final var path = resourceID.getPath();
-        final var idStr = path.substring(path.lastIndexOf('/') + 1);
-        final var builder = getRequestBuilder();
-        builder.url(new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/broker/remove/" + idStr)
-                .addQueryParameter("broker", brokerUri)
-                .build());
-        builder.post(RequestBody.create(new byte[0], null));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient deleteResourceAtBroker] Deleting Resource at Broker failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String deleteResourceRepresentation(final String resourceID,
-                                               final String representationID) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient deleteResourceRepresentation] Deleting representation %s from resource %s at %s",
-                representationID,
-                resourceID,
-                dataSpaceConnectorHost));
-
-
-        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
-        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.getMappedId(URI.create(representationID));
-        dataSpaceConnectorResourceMapper.deleteResourceIDPair(URI.create(representationID));
-
-        final var builder = getRequestBuilder();
-        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
-        builder.delete();
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient deleteResourceRepresentation] Deleting Representation failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String registerResourceRepresentation(final String resourceID,
-                                                 final Representation representation,
-                                                 final String endpointId) throws IOException {
-        log.info(String.format("---- [DataspaceConnectorClient registerResourceRepresentation] Registering resource at %s", dataSpaceConnectorHost));
-
-        final var mappedRepresentation = dataSpaceConnectorResourceMapper.mapRepresentation(representation);
-        final var backendSource = dataSpaceConnectorResourceMapper.createBackendSource(endpointId, representation);
-        mappedRepresentation.setSource(backendSource);
-
-        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
-        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.readUUIDFromURI(representation.getId());
-        final var resourceJsonLD = MAPPER.writeValueAsString(mappedRepresentation);
-
-        log.info("---- [DataspaceConnectorClient registerResourceRepresentation] Mapped representation: " + resourceJsonLD);
-
-        final var builder = getRequestBuilder();
-        builder.url(new HttpUrl.Builder()
-                .scheme(protocol)
-                .host(dataSpaceConnectorHost)
-                .port(dataSpaceConnectorPort)
-                .addPathSegments("admin/api/resources/" + mappedResourceID + "/representation")
-                .addQueryParameter("id", mappedRepresentationID.toString())
-                .build());
-        builder.post(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient registerResourceRepresentation] Registering Representation failed!");
-        }
-
-        final var body = Objects.requireNonNull(response.body()).string();
-        final var uuid = dataSpaceConnectorResourceMapper.createFromResponse(body, representation.getId());
-
-        if (uuid == null) {
-            log.warn("---- [DataspaceConnectorClient registerResourceRepresentation] Could not parse ID from response!");
-        } else {
-            log.info("---- [DataspaceConnectorClient registerResourceRepresentation] UUID is : " + uuid);
-        }
-
-        return body;
-    }
-
-    @Override
-    public String updateResourceRepresentation(final String resourceID,
-                                               final String representationID,
-                                               final Representation representation,
-                                               final String endpointId) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient updateResourceRepresentation] Updating representation %s for resource %s at %s",
-                representationID,
-                resourceID,
-                dataSpaceConnectorHost));
-
-        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
-        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(representationID));
-        final var mappedRepresentation = dataSpaceConnectorResourceMapper.mapRepresentation(representation);
-        final var backendSource = dataSpaceConnectorResourceMapper.createBackendSource(endpointId, representation);
-
-        mappedRepresentation.setSource(backendSource);
-
-        final var resourceJsonLD = MAPPER.writeValueAsString(mappedRepresentation);
-
-        log.info("---- [DataspaceConnectorClient updateResourceRepresentation] Mapped representation: " + resourceJsonLD);
-
-        final var builder = getRequestBuilder();
-
-        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
-        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient updateResourceRepresentation] Updating Representation failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String updateCustomResourceRepresentation(final String resourceID,
-                                                     final String representationID,
-                                                     final ResourceRepresentation resourceRepresentation) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient updateCustomResourceRepresentation] Updating representation %s for resource %s at %s",
-                representationID,
-                resourceID,
-                dataSpaceConnectorHost));
-
-        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
-        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.getMappedId(URI.create(representationID));
-        final var resourceJsonLD = MAPPER.writeValueAsString(resourceRepresentation);
-
-        log.info("---- [DataspaceConnectorClient updateCustomResourceRepresentation] Mapped representation: " + resourceJsonLD);
-
-        final var builder = getRequestBuilder();
-        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
-        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
-        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
-                dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient updateCustomResourceRepresentation] Updating Resource-Representation failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String updateResourceContract(final String resourceID, final String contract) throws IOException {
-        log.info(String.format(
-                "---- [DataspaceConnectorClient updateResourceContract] updating contract for resource at %s",
-                dataSpaceConnectorHost));
-
-        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
-
-        final var builder = getRequestBuilder();
-        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/contract");
-        builder.put(RequestBody.create(contract, okhttp3.MediaType.parse("application/ld+json")));
-        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
-                dataSpaceConnectorApiPassword));
-
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient updateResourceContract] Updating contract failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
     public String getPolicyPattern(final String policy) throws IOException {
         log.info("---- [DataspaceConnectorClient getPolicyPattern] Get pattern for policy");
 
@@ -673,59 +218,5 @@ public class DataspaceConnectorClient implements DefaultConnectorClient {
         }
 
         return Objects.requireNonNull(response.body()).string();
-    }
-
-    @Override
-    public String updateResource(final URI resourceID, final Resource resource) throws IOException {
-        log.info(String.format("---- [DataspaceConnectorClient updateResource] updating resource at %s", dataSpaceConnectorHost));
-
-        final var mappedResource = dataSpaceConnectorResourceMapper.getMetadata(resource);
-        final var path = resourceID.getPath();
-        final var idStr = path.substring(path.lastIndexOf('/') + 1);
-        final var resourceUUID = UUID.fromString(idStr);
-
-        final var backendSource = new BackendSource();
-        try {
-            final var requestBackendBuilder = getRequestBuilder();
-            requestBackendBuilder.url(connectorBaseUrl + "admin/api/resources/" + resourceUUID);
-            requestBackendBuilder.get();
-            requestBackendBuilder.header("Authorization",
-                    Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-
-            final var request = requestBackendBuilder.build();
-            final var response = DispatchRequest.sendToDataspaceConnector(request);
-            final var mapper = new ObjectMapper();
-            final var jsonTree = mapper.readTree(Objects.requireNonNull(response.body()).string());
-
-            final var source = jsonTree.findValue("source");
-            backendSource.setType(BackendSource.Type.valueOf(source.get("type").asText().toUpperCase().replace("-", "_")));
-            backendSource.setUrl(URI.create(source.get("url").asText()));
-            backendSource.setUsername(source.get("username").asText());
-            backendSource.setPassword(source.get("password").asText());
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-
-        mappedResource.getRepresentations().get(0).setSource(backendSource);
-        final var resourceJsonLD = MAPPER.writeValueAsString(mappedResource);
-
-        final var builder = getRequestBuilder();
-        builder.url(connectorBaseUrl + "admin/api/resources/" + resourceUUID);
-        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
-        builder.header("Authorization",
-                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
-        final var request = builder.build();
-        final var response = DispatchRequest.sendToDataspaceConnector(request);
-
-        if (!response.isSuccessful()) {
-            log.warn("---- [DataspaceConnectorClient updateResource] Updating Resource failed!");
-        }
-
-        return Objects.requireNonNull(response.body()).string();
-    }
-
-    @NotNull
-    private Request.Builder getRequestBuilder() {
-        return new Request.Builder();
     }
 }

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceResourceClient.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/DataspaceResourceClient.java
@@ -1,0 +1,389 @@
+package de.fraunhofer.isst.configmanager.connector.dataspaceconnector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.fraunhofer.iais.eis.Representation;
+import de.fraunhofer.iais.eis.Resource;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
+import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.BackendSource;
+import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceRepresentation;
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Credentials;
+import okhttp3.HttpUrl;
+import okhttp3.RequestBody;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@ConditionalOnExpression("${dataspace.connector.enabled:false}")
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class DataspaceResourceClient extends DataspaceClient implements DefaultResourceClient {
+
+    public DataspaceResourceClient(ResourceMapper dataSpaceConnectorResourceMapper) {
+        super(dataSpaceConnectorResourceMapper);
+    }
+
+    @Override
+    public String getOfferedResourcesAsJsonString() throws IOException {
+        final var baseConnectorNode = getJsonNodeOfBaseConnector();
+        final var offeredResourceNode = baseConnectorNode.findValue("ids:offeredResource");
+        return offeredResourceNode.toString();
+    }
+
+    @Override
+    public String getRequestedResourcesAsJsonString() throws IOException {
+        final var baseConnectorNode = getJsonNodeOfBaseConnector();
+        final var requestedResourceNode = baseConnectorNode.findValue("ids:requestedResource");
+        return requestedResourceNode.toString();
+    }
+
+    private JsonNode getJsonNodeOfBaseConnector() throws IOException {
+        final var connectorUrl = connectorBaseUrl + "admin/api/connector";
+
+        final var builder = getRequestBuilder();
+        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
+                dataSpaceConnectorApiPassword));
+        builder.url(connectorUrl);
+        builder.get();
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient getJsonNodeOfBaseConnector] Could not get BaseConnector");
+        }
+
+        final var body = Objects.requireNonNull(response.body()).string();
+        final var mapper = new ObjectMapper();
+
+        return mapper.readTree(body);
+    }
+
+    @Override
+    public Resource getRequestedResource(final String accessURL, final String resourceId) throws IOException {
+        final var builder = getRequestBuilder();
+        final var urlBuilder = new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/request/description")
+                .addQueryParameter("recipient", accessURL)
+                .addQueryParameter("requestedResource", resourceId);
+
+        final var url = urlBuilder.build();
+        builder.url(url);
+        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+        builder.post(RequestBody.create(new byte[0], null));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn(String.format("---- [DataspaceConnectorClient getRequestedResource] Could not get BaseConnector from %s!", dataSpaceConnectorHost));
+        }
+
+        final var body = Objects.requireNonNull(response.body()).string();
+        final var splitBody = body.split("\n", 2);
+        final var resource = splitBody[1].substring(10);
+
+        Resource deserializedResource = null;
+        try {
+            deserializedResource = SERIALIZER.deserialize(resource, Resource.class);
+        } catch (IOException e) {
+            log.error("---- [DataspaceConnectorClient getRequestedResource] SERIALIZER.deserialize threw IOException");
+            log.error(e.getMessage(), e);
+        }
+
+        return deserializedResource;
+    }
+
+    @Override
+    public String registerResource(final Resource resource) throws IOException {
+        log.info("---- [DataspaceConnectorClient registerResource] Registering resource...");
+
+        final var mappedResource = dataSpaceConnectorResourceMapper.getMetadata(resource);
+        final var resourceJsonLD = MAPPER.writeValueAsString(mappedResource);
+
+        log.info("---- [DataspaceConnectorClient registerResource] New resource: " + resourceJsonLD);
+
+        final var builder = getRequestBuilder();
+        final var path = resource.getId().getPath();
+        final var idStr = path.substring(path.lastIndexOf('/') + 1);
+
+        final var url = new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/resources/resource")
+                .addQueryParameter("id", idStr)
+                .build();
+        builder.url(url);
+        builder.post(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld" +
+                "+json")));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        log.info("---- [DataspaceConnectorClient registerResource] " + url.toString());
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient registerResource] Registering Resource failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String deleteResource(final URI resourceID) throws IOException {
+        log.info(String.format("---- [DataspaceConnectorClient deleteResource] deleting resource %s at %s", resourceID,
+                dataSpaceConnectorHost));
+
+        final var path = resourceID.getPath();
+        final var idStr = path.substring(path.lastIndexOf('/') + 1);
+
+        final var builder = getRequestBuilder();
+        builder.url(connectorBaseUrl + "admin/api/resources/" + idStr);
+        builder.delete();
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient deleteResource] Deleting Resource failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String deleteResourceRepresentation(final String resourceID,
+                                               final String representationID) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient deleteResourceRepresentation] Deleting representation %s from resource %s at %s",
+                representationID,
+                resourceID,
+                dataSpaceConnectorHost));
+
+
+        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
+        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.getMappedId(URI.create(representationID));
+        dataSpaceConnectorResourceMapper.deleteResourceIDPair(URI.create(representationID));
+
+        final var builder = getRequestBuilder();
+        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
+        builder.delete();
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient deleteResourceRepresentation] Deleting Representation failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String registerResourceRepresentation(final String resourceID,
+                                                 final Representation representation,
+                                                 final String endpointId) throws IOException {
+        log.info(String.format("---- [DataspaceConnectorClient registerResourceRepresentation] Registering resource at %s", dataSpaceConnectorHost));
+
+        final var mappedRepresentation = dataSpaceConnectorResourceMapper.mapRepresentation(representation);
+        final var backendSource = dataSpaceConnectorResourceMapper.createBackendSource(endpointId, representation);
+        mappedRepresentation.setSource(backendSource);
+
+        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
+        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.readUUIDFromURI(representation.getId());
+        final var resourceJsonLD = MAPPER.writeValueAsString(mappedRepresentation);
+
+        log.info("---- [DataspaceConnectorClient registerResourceRepresentation] Mapped representation: " + resourceJsonLD);
+
+        final var builder = getRequestBuilder();
+        builder.url(new HttpUrl.Builder()
+                .scheme(protocol)
+                .host(dataSpaceConnectorHost)
+                .port(dataSpaceConnectorPort)
+                .addPathSegments("admin/api/resources/" + mappedResourceID + "/representation")
+                .addQueryParameter("id", mappedRepresentationID.toString())
+                .build());
+        builder.post(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient registerResourceRepresentation] Registering Representation failed!");
+        }
+
+        final var body = Objects.requireNonNull(response.body()).string();
+        final var uuid = dataSpaceConnectorResourceMapper.createFromResponse(body, representation.getId());
+
+        if (uuid == null) {
+            log.warn("---- [DataspaceConnectorClient registerResourceRepresentation] Could not parse ID from response!");
+        } else {
+            log.info("---- [DataspaceConnectorClient registerResourceRepresentation] UUID is : " + uuid);
+        }
+
+        return body;
+    }
+
+    @Override
+    public String updateResourceRepresentation(final String resourceID,
+                                               final String representationID,
+                                               final Representation representation,
+                                               final String endpointId) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient updateResourceRepresentation] Updating representation %s for resource %s at %s",
+                representationID,
+                resourceID,
+                dataSpaceConnectorHost));
+
+        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
+        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(representationID));
+        final var mappedRepresentation = dataSpaceConnectorResourceMapper.mapRepresentation(representation);
+        final var backendSource = dataSpaceConnectorResourceMapper.createBackendSource(endpointId, representation);
+
+        mappedRepresentation.setSource(backendSource);
+
+        final var resourceJsonLD = MAPPER.writeValueAsString(mappedRepresentation);
+
+        log.info("---- [DataspaceConnectorClient updateResourceRepresentation] Mapped representation: " + resourceJsonLD);
+
+        final var builder = getRequestBuilder();
+
+        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
+        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient updateResourceRepresentation] Updating Representation failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String updateCustomResourceRepresentation(final String resourceID,
+                                                     final String representationID,
+                                                     final ResourceRepresentation resourceRepresentation) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient updateCustomResourceRepresentation] Updating representation %s for resource %s at %s",
+                representationID,
+                resourceID,
+                dataSpaceConnectorHost));
+
+        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
+        final var mappedRepresentationID = dataSpaceConnectorResourceMapper.getMappedId(URI.create(representationID));
+        final var resourceJsonLD = MAPPER.writeValueAsString(resourceRepresentation);
+
+        log.info("---- [DataspaceConnectorClient updateCustomResourceRepresentation] Mapped representation: " + resourceJsonLD);
+
+        final var builder = getRequestBuilder();
+        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/" + mappedRepresentationID);
+        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
+        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
+                dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient updateCustomResourceRepresentation] Updating Resource-Representation failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String updateResourceContract(final String resourceID, final String contract) throws IOException {
+        log.info(String.format(
+                "---- [DataspaceConnectorClient updateResourceContract] updating contract for resource at %s",
+                dataSpaceConnectorHost));
+
+        final var mappedResourceID = dataSpaceConnectorResourceMapper.readUUIDFromURI(URI.create(resourceID));
+
+        final var builder = getRequestBuilder();
+        builder.url(connectorBaseUrl + "admin/api/resources/" + mappedResourceID + "/contract");
+        builder.put(RequestBody.create(contract, okhttp3.MediaType.parse("application/ld+json")));
+        builder.header("Authorization", Credentials.basic(dataSpaceConnectorApiUsername,
+                dataSpaceConnectorApiPassword));
+
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient updateResourceContract] Updating contract failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+
+    @Override
+    public String updateResource(final URI resourceID, final Resource resource) throws IOException {
+        log.info(String.format("---- [DataspaceConnectorClient updateResource] updating resource at %s", dataSpaceConnectorHost));
+
+        final var mappedResource = dataSpaceConnectorResourceMapper.getMetadata(resource);
+        final var path = resourceID.getPath();
+        final var idStr = path.substring(path.lastIndexOf('/') + 1);
+        final var resourceUUID = UUID.fromString(idStr);
+
+        final var backendSource = new BackendSource();
+        try {
+            final var requestBackendBuilder = getRequestBuilder();
+            requestBackendBuilder.url(connectorBaseUrl + "admin/api/resources/" + resourceUUID);
+            requestBackendBuilder.get();
+            requestBackendBuilder.header("Authorization",
+                    Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+
+            final var request = requestBackendBuilder.build();
+            final var response = DispatchRequest.sendToDataspaceConnector(request);
+            final var mapper = new ObjectMapper();
+            final var jsonTree = mapper.readTree(Objects.requireNonNull(response.body()).string());
+
+            final var source = jsonTree.findValue("source");
+            backendSource.setType(BackendSource.Type.valueOf(source.get("type").asText().toUpperCase().replace("-", "_")));
+            backendSource.setUrl(URI.create(source.get("url").asText()));
+            backendSource.setUsername(source.get("username").asText());
+            backendSource.setPassword(source.get("password").asText());
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+
+        mappedResource.getRepresentations().get(0).setSource(backendSource);
+        final var resourceJsonLD = MAPPER.writeValueAsString(mappedResource);
+
+        final var builder = getRequestBuilder();
+        builder.url(connectorBaseUrl + "admin/api/resources/" + resourceUUID);
+        builder.put(RequestBody.create(resourceJsonLD, okhttp3.MediaType.parse("application/ld+json")));
+        builder.header("Authorization",
+                Credentials.basic(dataSpaceConnectorApiUsername, dataSpaceConnectorApiPassword));
+        final var request = builder.build();
+        final var response = DispatchRequest.sendToDataspaceConnector(request);
+
+        if (!response.isSuccessful()) {
+            log.warn("---- [DataspaceConnectorClient updateResource] Updating Resource failed!");
+        }
+
+        return Objects.requireNonNull(response.body()).string();
+    }
+}

--- a/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/ResourceMapper.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/connector/dataspaceconnector/ResourceMapper.java
@@ -1,19 +1,15 @@
 package de.fraunhofer.isst.configmanager.connector.dataspaceconnector;
 
-import de.fraunhofer.iais.eis.Artifact;
-import de.fraunhofer.iais.eis.BasicAuthenticationImpl;
-import de.fraunhofer.iais.eis.GenericEndpoint;
-import de.fraunhofer.iais.eis.Representation;
-import de.fraunhofer.iais.eis.Resource;
+import de.fraunhofer.iais.eis.*;
 import de.fraunhofer.iais.eis.ids.jsonld.Serializer;
 import de.fraunhofer.iais.eis.util.RdfResource;
 import de.fraunhofer.iais.eis.util.TypedLiteral;
+import de.fraunhofer.isst.configmanager.api.service.EndpointService;
 import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.BackendSource;
 import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceIDPair;
 import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceMetadata;
 import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.ResourceRepresentation;
 import de.fraunhofer.isst.configmanager.connector.dataspaceconnector.model.repos.ResourceIDPairRepository;
-import de.fraunhofer.isst.configmanager.api.service.EndpointService;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.springframework.stereotype.Service;

--- a/src/test/java/de/fraunhofer/isst/configmanager/api_test/BrokerUIAPITest.java
+++ b/src/test/java/de/fraunhofer/isst/configmanager/api_test/BrokerUIAPITest.java
@@ -1,12 +1,15 @@
 package de.fraunhofer.isst.configmanager.api_test;
 
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultBrokerClient;
 import de.fraunhofer.isst.configmanager.connector.clients.DefaultConnectorClient;
+import de.fraunhofer.isst.configmanager.connector.clients.DefaultResourceClient;
 import de.fraunhofer.isst.configmanager.model.config.CustomBroker;
 import de.fraunhofer.isst.configmanager.api.service.BrokerService;
 import de.fraunhofer.isst.configmanager.api.service.ResourceService;
 import de.fraunhofer.isst.configmanager.api.controller.BrokerController;
 import de.fraunhofer.isst.configmanager.util.TestUtil;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -33,6 +36,12 @@ public class BrokerUIAPITest {
 
     @MockBean
     private DefaultConnectorClient defaultConnectorClient;
+
+    @MockBean
+    private DefaultBrokerClient defaultBrokerClient;
+
+    @MockBean
+    private DefaultResourceClient defaultResourceClient;
 
     @MockBean
     private ResourceService resourceService;


### PR DESCRIPTION
Split DataspaceConnectorClient into 3 Clients for Connector, Resource and Broker, create a DataspaceClient abstract superclass containing shared fields and methods, keeping client Classes smaller.