### PR TITLE
Infomodel Java 4.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,9 +212,9 @@
         </dependency>
 
         <dependency>
-            <groupId>de.fraunhofer.iais.eis.ids.infomodel</groupId>
+            <groupId>de.fraunhofer.iais.eis.infomodel</groupId>
             <artifactId>util</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.6</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>de.fraunhofer.iais.eis.ids.infomodel</groupId>
             <artifactId>java</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.6</version>
         </dependency>
 
         <dependency>
@@ -220,7 +220,7 @@
         <dependency>
             <groupId>de.fraunhofer.iais.eis.ids</groupId>
             <artifactId>infomodel-serializer</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>de.fraunhofer.iais.eis.ids.infomodel</groupId>

--- a/src/main/java/de/fraunhofer/isst/configmanager/api/service/ConfigModelService.java
+++ b/src/main/java/de/fraunhofer/isst/configmanager/api/service/ConfigModelService.java
@@ -6,6 +6,7 @@ import de.fraunhofer.iais.eis.ConfigurationModel;
 import de.fraunhofer.iais.eis.ConfigurationModelBuilder;
 import de.fraunhofer.iais.eis.ConfigurationModelImpl;
 import de.fraunhofer.iais.eis.ConnectorDeployMode;
+import de.fraunhofer.iais.eis.ConnectorEndpointBuilder;
 import de.fraunhofer.iais.eis.ConnectorStatus;
 import de.fraunhofer.iais.eis.LogLevel;
 import de.fraunhofer.iais.eis.ProxyBuilder;
@@ -113,12 +114,16 @@ public class ConfigModelService {
                                   final String keyStore,
                                   final String keyStorePassword) {
 
+        final var connectorEndpointBuilder = new ConnectorEndpointBuilder();
+        connectorEndpointBuilder._accessURL_(URI.create("https://example.com"));
+
         final var connector = new BaseConnectorBuilder()
-                ._inboundModelVersion_(new ArrayList<>(List.of("3.1.0")))
-                ._outboundModelVersion_("3.1.0")
+                ._inboundModelVersion_(new ArrayList<>(List.of("4.0.6")))
+                ._outboundModelVersion_("4.0.6")
                 ._securityProfile_(SecurityProfile.BASE_SECURITY_PROFILE)
                 ._maintainer_(URI.create("https://example.com"))
                 ._curator_(URI.create("https://example.com"))
+                ._hasDefaultEndpoint_(connectorEndpointBuilder.build())
                 .build();
 
         final var configurationModel = new ConfigurationModelBuilder()

--- a/src/test/java/de/fraunhofer/isst/configmanager/petrinet/builder/InfomodelPetriNetBuilderTest.java
+++ b/src/test/java/de/fraunhofer/isst/configmanager/petrinet/builder/InfomodelPetriNetBuilderTest.java
@@ -68,11 +68,13 @@ class InfomodelPetriNetBuilderTest {
         }
         var subroutes = new ArrayList<RouteStep>();
         for (int i = 0; i < ThreadLocalRandom.current().nextInt(MINIMUM_SUBROUTE,MAXIMUM_SUBROUTE); i++){
-            subroutes.add(new RouteStepBuilder(URI.create("http://subroute" + i))._appRouteStart_(randomSubList(endpointlist))._appRouteEnd_(randomSubList(endpointlist)).build());
+            subroutes.add(new RouteStepBuilder(URI.create("http://subroute" + i))
+                    ._appRouteStart_((ArrayList<Endpoint>) randomSubList(endpointlist))
+                    ._appRouteEnd_((ArrayList<Endpoint>) randomSubList(endpointlist)).build());
         }
         var appRoute = new AppRouteBuilder(URI.create("http://approute"))
-                ._appRouteStart_(randomSubList(endpointlist))
-                ._appRouteEnd_(randomSubList(endpointlist))
+                ._appRouteStart_((ArrayList<Endpoint>) randomSubList(endpointlist))
+                ._appRouteEnd_((ArrayList<Endpoint>) randomSubList(endpointlist))
                 ._hasSubRoute_(subroutes)
                 .build();
 


### PR DESCRIPTION
- ids:hasDefaultEndpoint in ConfigModel now mandatory
- changed prefix at Deploymode etc.
- fixed usage control duration until (issue 105)